### PR TITLE
[DATA-5768][DATA-3562] Support env vars passing into the diff command

### DIFF
--- a/src/diffa/config.py
+++ b/src/diffa/config.py
@@ -51,6 +51,9 @@ class DBConfig:
 
     def _parse_db_info(self):
         try:
+            # Users can ref an env var in the DB_URI in the command
+            if self.db_uri.startswith("$"):
+                self.db_uri = os.getenv(self.db_uri[1:], "")
             dns = dsnparse.parse(self.db_uri)
             parsed_db_info = self._extract_db_details(dns)
             self._validate_parsed_db_info(parsed_db_info)

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -14,7 +14,7 @@ from diffa.config import (
     DIFFA_CHECK_RUNS_TABLE,
 )
 
-
+@patch.dict(os.environ, {"SOURCE_URI": "postgresql://user:password@localhost:5432/mydb"})
 @pytest.mark.parametrize(
     "db_uri, db_name, db_schema, db_table, expected_parsed_config",
     [
@@ -57,6 +57,24 @@ from diffa.config import (
         # Case 3: Complete db_uri, but missing database parameter (fallback to db_uri value)
         (
             "postgresql://user:password@localhost:5432/mydb",
+            None,
+            "myschema",
+            "users",
+            {
+                "host": "localhost",
+                "scheme": "postgresql",
+                "port": 5432,
+                "database": "mydb",
+                "user": "user",
+                "password": "password",
+                "schema": "myschema",
+                "table": "users",
+                "db_uri": "postgresql://user:password@localhost:5432/mydb",
+            },
+        ),
+        # Case 4: Complete db_uri but inputing using env var, missing database parametter
+        (
+            "$SOURCE_URI",
             None,
             "myschema",
             "users",

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -72,7 +72,7 @@ from diffa.config import (
                 "db_uri": "postgresql://user:password@localhost:5432/mydb",
             },
         ),
-        # Case 4: Complete db_uri but inputing using env var, missing database parametter
+        # Case 4: Complete db_uri but inputting using env var, missing database parameter
         (
             "$SOURCE_URI",
             None,
@@ -90,7 +90,7 @@ from diffa.config import (
                 "db_uri": "postgresql://user:password@localhost:5432/mydb",
             },
         ),
-        # Case 5: Complete db_uri but email-format username, missing database parametter
+        # Case 5: Complete db_uri but email-format username, missing database parameter
         (
             "postgresql://user@email.com:password@localhost:5432/mydb",
             None,

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -90,6 +90,24 @@ from diffa.config import (
                 "db_uri": "postgresql://user:password@localhost:5432/mydb",
             },
         ),
+        # Case 5: Complete db_uri but email-format username, missing database parametter
+        (
+            "postgresql://user@email.com:password@localhost:5432/mydb",
+            None,
+            "myschema",
+            "users",
+            {
+                "host": "localhost",
+                "scheme": "postgresql",
+                "port": 5432,
+                "database": "mydb",
+                "user": "user@email.com",
+                "password": "password",
+                "schema": "myschema",
+                "table": "users",
+                "db_uri": "postgresql://user@email.com:password@localhost:5432/mydb",
+            },
+        ),
     ],
 )
 def test_db_config_parse_db_info(


### PR DESCRIPTION
<!-- Title format: [Target Kind] [Group] [Partner]* (?/N) Single line summary [JIRA] [PostDeploy JIRA]

Note:
- (?/N) if there are multiple PRs for the same story
- * is optional
- Refer to https://www.notion.so/kaligo/Pull-request-workflow-7a2c4f005c0f432ea86a502fb57c7269#dcf6f11e0ba146a09b28b22104f3bd06 for more info

-->

<!-- Jira link here -->
https://kaligo.atlassian.net/browse/DATA-5768
https://kaligo.atlassian.net/browse/DATA-3562

# Background

<!-- Describe why this PR was needed -->
Currently, in the Diffa, users can input into the Diffa the source-uris 
```
diffa data-diff \
--source-db-uri
--target-db-uri
```
However, doing so can introduce the security breach because it can leak the source systems' creds, especially in the case we need to adopt this feature in the Airflow.

One of the examples for this is that, in Dataops-global where the source systems can come from different database systems, we can not the env var approach in this case to pass the db-uris into the Diffa. In this case, we have to pass them directly into the diffa command, causing the security risks. 

# Design

<!-- Describe what changes are made in this PR to meet the requirements, justify if necessary -->
We can support another feature, for db-uris in the command, beside taking in the URI plain string text, we can pass the env var into it. 

In other words, db-uris can be take the 2 following options
```
diffa data-diff \
--source-db-uri  postgresql://test_user:test_past@test_host:5432/test_db
```
Or
```
export TEST_DB_URI=postgresql://test_user:test_past@test_host:5432/test_db

diffa data-diff
--source-db-uri $TEST_DB_URI
```

# Impact

<!-- Describe how the changes interact in the overall system, and how they might impact other components -->
- Reduce the possible security risk. 


# Testing

<!-- Describe the test scenarios -->
- All the unit tests have passed
<img width="1003" alt="Screenshot 2025-05-05 at 14 00 20" src="https://github.com/user-attachments/assets/74f4aeb3-cd74-4cb2-a95b-58085c7eaa0d" />

